### PR TITLE
Support Conversions (implicit or explicit) and other Unary operations…

### DIFF
--- a/LochNessBuilder/Builder.cs
+++ b/LochNessBuilder/Builder.cs
@@ -142,8 +142,18 @@ namespace LochNessBuilder
             var instance = GetInstance();
             var prop = GetProp(selector, instance);
             Expression<Func<TProp>> valueInvoker = () => value();
+            Expression setExpression;
 
-            var setExpression = Expression.Assign(prop, Expression.Invoke(valueInvoker));
+            var unaryExpression = selector.Body as UnaryExpression;
+            if (unaryExpression != null && unaryExpression.NodeType == ExpressionType.Convert)
+            {
+                setExpression = Expression.Convert(valueInvoker.Body, typeof(TProp));
+            }
+            else
+            {
+                setExpression = Expression.Assign(prop, Expression.Invoke(valueInvoker));
+            }
+
             var setLambda = Expression.Lambda<Action<TInstance>>(setExpression, instance).Compile();
 
             return new Builder<TInstance>(Blueprint.Plus(setLambda), PostBuildBlueprint);

--- a/LochNessBuilder/Extensions/ExpressionExtensions.cs
+++ b/LochNessBuilder/Extensions/ExpressionExtensions.cs
@@ -7,8 +7,12 @@ namespace LochNessBuilder.Extensions
     {
         public static string GetMemberName<TInstance, TProp>(this Expression<Func<TInstance, TProp>> selector)
         {
-            var selectorBody = (MemberExpression)selector.Body;
-            return selectorBody.Member.Name;
+            var unaryExpression = selector.Body as UnaryExpression;
+            if (unaryExpression != null && unaryExpression.NodeType == ExpressionType.Convert)
+            {
+                return ((MemberExpression)unaryExpression.Operand).Member.Name;
+            }
+            return ((MemberExpression)selector.Body).Member.Name;
         }
     }
 }


### PR DESCRIPTION
… in builder declarations

Allows for casts (implicit or otherwise) in the expression. Lifted out of the Redburn codebase.
I think it was mainly dealing with e.g. setting a `short` property to value "1" (an int)?

Not hugely fussed about this feature either way.